### PR TITLE
feat(server): support RepoConfigDir array

### DIFF
--- a/cmd/yukid/README.md
+++ b/cmd/yukid/README.md
@@ -34,7 +34,7 @@ fs = "default"
 ## 每个仓库的同步配置存放的文件夹
 ## 每个配置的后缀名必须是 `.yaml`
 ## 配置的格式参考下方 Repo Configuration
-repo_config_dir = "/path/to/config-dir"
+repo_config_dir = ["/path/to/config-dir"]
 
 ## 设置 Docker Daemon 地址
 ## unix local socket: unix:///var/run/docker.sock
@@ -94,4 +94,49 @@ volumes: # 同步的时候需要挂载的 volume
   # 注意: 由于 MongoDB 的限制，key 不能包含 `.`
   /etc/passwd: /etc/passwd:ro
   /ssh: /home/mirror/.ssh:ro
+```
+
+当存在多个目录时，配置将被字段级合并，同名字段 last win。举例：
+
+daemon.yaml
+```yaml
+repo_config_dir = ["common/", "override/"]
+```
+
+common/centos.yaml
+```yaml
+name: centos
+storageDir: /srv/repo/centos/
+image: ustcmirror/rsync:latest
+interval: 0 0 * * *
+envs:
+  RSYNC_HOST: msync.centos.org
+  RSYNC_PATH: CentOS/
+logRotCycle: 10
+retry: 1
+```
+
+override/centos.yaml
+```yaml
+interval: 17 3-23/4 * * *
+envs:
+  RSYNC_MAXDELETE: '200000'
+```
+
+`yukictl repo ls centos`
+
+```json
+{
+  "name": "centos",
+  "interval": "17 3-23/4 * * *",
+  "image": "ustcmirror/rsync:latest",
+  "storageDir": "/srv/repo/centos/",
+  "logRotCycle": 10,
+  "retry": 2,
+  "envs": {
+    "RSYNC_HOST": "msync.centos.org",
+    "RSYNC_MAXDELETE": "200000",
+    "RSYNC_PATH": "CentOS/"
+  }
+}
 ```

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -21,7 +21,7 @@ type AppConfig struct {
 
 	Owner                 string   `mapstructure:"owner,omitempty" validate:"-"`
 	LogDir                string   `mapstructure:"log_dir,omitempty" validate:"-"`
-	RepoConfigDir         string   `mapstructure:"repo_config_dir,omitempty" validate:"required"`
+	RepoConfigDir         []string   `mapstructure:"repo_config_dir,omitempty" validate:"required"`
 	LogLevel              string   `mapstructure:"log_level,omitempty" validate:"omitempty,eq=debug|eq=info|eq=warn|eq=error"`
 	ListenAddr            string   `mapstructure:"listen_addr,omitempty" validate:"omitempty,hostport"`
 	BindIP                string   `mapstructure:"bind_ip,omitempty" validate:"omitempty,ip"`
@@ -34,7 +34,7 @@ type Config struct {
 	core.Config
 	Owner                 string
 	LogDir                string
-	RepoConfigDir         string
+	RepoConfigDir         []string
 	LogLevel              logrus.Level
 	ListenAddr            string
 	BindIP                string

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -346,7 +346,7 @@ func (s *Server) loadRepo(dirs []string, file string) (*api.Repository, error) {
 		data, err := ioutil.ReadFile(filepath.Join(dir, file))
 		if err != nil {
 			errn--
-			if errn > 0 {
+			if errn > 0 && os.IsNotExist(err) {
 				continue
 			} else {
 				return nil, badRequest(err)

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -82,8 +82,10 @@ func NewWithConfig(cfg *Config) (*Server, error) {
 	if err := os.MkdirAll(cfg.LogDir, os.ModePerm); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(cfg.RepoConfigDir, os.ModePerm); err != nil {
-		return nil, err
+	for _, dir := range cfg.RepoConfigDir {
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return nil, err
+		}
 	}
 	coreCfg := core.Config{
 		Debug:          cfg.Debug,


### PR DESCRIPTION
This feature is useful to whom maintenances multiple mirror servers.

eg:
on `mirrors2.s.u.o`:
```yaml
repo_config_dir = ["common/", "mirrors2/"]
```
on `mirrors4.s.u.o`:
```yaml
repo_config_dir = ["common/", "mirrors4/"]
```

BTW, it's compatible with old style config, namely, assign either string or array.