### PR TITLE
[BREAKING CHANGE] `seccomp_profile` is no longer configurable

### DIFF
--- a/cmd/yukid/README.md
+++ b/cmd/yukid/README.md
@@ -88,12 +88,6 @@ repo_config_dir = ["/path/to/config-dir"]
 ## 如果为 0 的话则不会超时。注意修改的配置仅对新启动的同步容器生效
 ## 默认值为 0
 #sync_timeout = "48h"
-
-## 修改同步时的 seccomp profile，用于特殊用途的容器
-## 例如，使用 seccomp user notify 的程序需要放行一些相关的系统调用
-## 留空时使用 docker daemon 默认的 seccomp 配置
-## 默认值为空
-#seccomp_profile = "/path/to/seccomp/profile.json"
 ```
 
 ### Repo Configuration

--- a/pkg/docker/cli.go
+++ b/pkg/docker/cli.go
@@ -26,8 +26,7 @@ type RunContainerConfig struct {
 	Name   string
 
 	// HostConfig
-	SecurityOpt []string
-	Binds       []string
+	Binds []string
 
 	// NetworkingConfig
 	Network string
@@ -80,8 +79,7 @@ func (c *clientImpl) RunContainer(ctx context.Context, config RunContainerConfig
 		}
 
 		cfg.Spec.HostConfig = containerapi.HostConfig{
-			Binds:       config.Binds,
-			SecurityOpt: config.SecurityOpt,
+			Binds: config.Binds,
 		}
 		cfg.Spec.HostConfig.Mounts = []mount.Mount{
 			{

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -22,7 +22,6 @@ type Config struct {
 	PostSync              []string      `mapstructure:"post_sync"`
 	ImagesUpgradeInterval time.Duration `mapstructure:"images_upgrade_interval" validate:"min=0"`
 	SyncTimeout           time.Duration `mapstructure:"sync_timeout" validate:"min=0"`
-	SeccompProfile        string        `mapstructure:"seccomp_profile" validate:"omitempty,filepath"`
 }
 
 var DefaultConfig = Config{

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -386,11 +386,6 @@ func (s *Server) syncRepo(ctx context.Context, name string, debug bool) error {
 		repo.User = s.config.Owner
 	}
 
-	var securityOpt []string
-	if len(s.config.SeccompProfile) > 0 {
-		securityOpt = append(securityOpt, "seccomp="+s.config.SeccompProfile)
-	}
-
 	envMap := repo.Envs
 	if len(envMap) == 0 {
 		envMap = make(map[string]string)
@@ -425,12 +420,11 @@ func (s *Server) syncRepo(ctx context.Context, name string, debug bool) error {
 				api.LabelRepoName:   repo.Name,
 				api.LabelStorageDir: repo.StorageDir,
 			},
-			Env:         envs,
-			Image:       repo.Image,
-			Name:        ctName,
-			SecurityOpt: securityOpt,
-			Binds:       binds,
-			Network:     repo.Network,
+			Env:     envs,
+			Image:   repo.Image,
+			Name:    ctName,
+			Binds:   binds,
+			Network: repo.Network,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
`seccomp_profile` was once introduced for the purpose of enforcing the outgoing ip of a container, but now we have a better alternative: put the container inside pre-defined special docker network, so we don't need to set `seccomp_profile` now. 

For more details, please refer to https://docs.ustclug.org/services/mirrors/docker/#routing.