### PR TITLE
docker: Fix container network specification

### DIFF
--- a/pkg/docker/cli.go
+++ b/pkg/docker/cli.go
@@ -93,7 +93,7 @@ func (c *clientImpl) RunContainer(ctx context.Context, config RunContainerConfig
 		case "host", "":
 			cfg.Spec.HostConfig.NetworkMode = "host"
 		default:
-			cfg.Spec.NetworkConfig.EndpointsConfig[config.Network] = &containerapi.EndpointSettings{}
+			cfg.Spec.HostConfig.NetworkMode = config.Network
 		}
 	}
 	ct, err := c.client.ContainerService().Create(ctx, "", setCfg)


### PR DESCRIPTION
Docker CLI 是将 `--network` 参数放在 HostConfig.NetworkMode 里的，此结论通过以下命令获得

```shell
$ nc -l -p 2375 <<< $'HTTP/1.1 200 OK\r\nServer: docker\r\n\r'
$ docker -H tcp://localhost run --rm --network=test alpine
```