### PR TITLE
fix: Exit with 1 when cmd execute fails

### DIFF
--- a/cmd/yukictl/yukictl.go
+++ b/cmd/yukictl/yukictl.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -25,5 +27,9 @@ func main() {
 	rootCmd.Flags().BoolVarP(&printVersion, "version", "V", false, "Print version information and quit")
 	f := factory.New(rootCmd.PersistentFlags())
 	yukictl.Register(rootCmd, f)
-	_ = rootCmd.Execute()
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/yukictl/yukictl.go
+++ b/cmd/yukictl/yukictl.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -25,5 +26,8 @@ func main() {
 	rootCmd.Flags().BoolVarP(&printVersion, "version", "V", false, "Print version information and quit")
 	f := factory.New(rootCmd.PersistentFlags())
 	yukictl.Register(rootCmd, f)
-	_ = rootCmd.Execute()
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/yukid/yukid.go
+++ b/cmd/yukid/yukid.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/signal"
 
@@ -44,5 +45,8 @@ func main() {
 	cmd.Flags().StringVar(&configPath, "config", "/etc/yuki/daemon.toml", "The path to config file")
 	cmd.Flags().BoolVarP(&printVersion, "version", "V", false, "Print version information and quit")
 
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/yukid/yukid.go
+++ b/cmd/yukid/yukid.go
@@ -44,5 +44,7 @@ func main() {
 	cmd.Flags().StringVar(&configPath, "config", "/etc/yuki/daemon.toml", "The path to config file")
 	cmd.Flags().BoolVarP(&printVersion, "version", "V", false, "Print version information and quit")
 
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
避免出现 systemd 认为服务启动没有失败，从而不 restart 的情况。